### PR TITLE
fix(eslint): disable import/group-exports in typescript

### DIFF
--- a/eslint/typescript.js
+++ b/eslint/typescript.js
@@ -8,5 +8,6 @@ module.exports = {
 	rules: {
 		'no-unused-vars': 'off',
 		'@typescript-eslint/no-unused-vars': 'error',
+		'import/group-exports': 'off'
 	},
 };


### PR DESCRIPTION
Disable import/group-exports in typescript