### PR TITLE
feat(perform): test helper to use playwright commands in your tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.42.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@playwright/test": "^1.40.1",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@web/dev-server": "^0.4.0",
         "@web/dev-server-esbuild": "^1.0.0",
         "@web/test-runner": "^0.18.0",
+        "@web/test-runner-commands": "^0.9.0",
         "@web/test-runner-playwright": "^0.11.0",
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^9.0.0",
@@ -1112,6 +1114,20 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^19.0.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
+      "dependencies": {
+        "playwright": "1.40.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -10658,11 +10674,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
-      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
       "dependencies": {
-        "playwright-core": "1.40.0"
+        "playwright-core": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -10675,9 +10691,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
-      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -44,11 +44,13 @@
     ]
   },
   "dependencies": {
+    "@playwright/test": "^1.40.1",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@web/dev-server": "^0.4.0",
     "@web/dev-server-esbuild": "^1.0.0",
     "@web/test-runner": "^0.18.0",
+    "@web/test-runner-commands": "^0.9.0",
     "@web/test-runner-playwright": "^0.11.0",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.0.0",

--- a/web/perform.js
+++ b/web/perform.js
@@ -1,0 +1,18 @@
+import { executeServerCommand } from '@web/test-runner-commands';
+
+let i = 0;
+export const perform = async (fn, ...args) => {
+	let result;
+
+	const resultGrabber = `__grabCommandResult${++i}`;
+	window[resultGrabber] = (_result) => (result = _result);
+
+	await executeServerCommand('cz-perform', {
+		fn: fn.toString(),
+		args,
+		resultGrabber,
+	});
+
+	delete window[resultGrabber];
+	return result;
+};

--- a/web/performer.mjs
+++ b/web/performer.mjs
@@ -1,0 +1,24 @@
+import { expect } from '@playwright/test';
+
+const perform = async (payload, context) => {
+	// eslint-disable-next-line no-eval
+	const fn = eval(payload.fn);
+	const result = await fn(context, ...payload.args);
+	await context.page.evaluate(
+		([grabber, result]) => window[grabber](result),
+		[payload.resultGrabber, result],
+	);
+	return true;
+};
+
+export const performer = () => ({
+	name: 'cz-performer',
+	// eslint-disable-next-line max-statements
+	async executeCommand({ command, payload, session }) {
+		if (command !== 'cz-perform') return;
+		if (session.browser.type !== 'playwright') return;
+
+		const page = session.browser.getPage(session.id);
+		return perform(payload, { session, page, expect });
+	},
+});

--- a/web/test-runner.mjs
+++ b/web/test-runner.mjs
@@ -1,6 +1,7 @@
 import { playwrightLauncher } from '@web/test-runner-playwright';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { nodeResolve } from './rollup.mjs';
+import { performer } from './performer.mjs';
 
 export default {
 	browsers: process.env.HEADED
@@ -26,5 +27,5 @@ export default {
 	files: ['**!(node_modules)/*.test.(j|t)s'],
 	testFramework: { config: { ui: 'tdd' } },
 	nodeResolve,
-	plugins: [esbuildPlugin({ ts: true })],
+	plugins: [esbuildPlugin({ ts: true }), performer()],
 };


### PR DESCRIPTION
Usage example:

```js
import { perform } from '@neovici/cfg/web/perform.js';
...
	test('can create pdf', async () => {
		const filename = await perform(async ({ page }) => {
			const downloadPromise = page.waitForEvent('download');
			await page.locator('button[title="Download images"]').click();
			const download = await downloadPromise;
			return download.suggestedFilename();
		});

		assert.equal(filename, 'archive.pdf');
	});
```